### PR TITLE
improvement: remove 'with_items' loop and use modern ansible loops

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: "Install, configure and manage PostgreSQL clusters"
   license: MIT
 
-  min_ansible_version: 2.0
+  min_ansible_version: 2.5
 
   platforms:
   - name: Ubuntu

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,17 +20,9 @@
   when: (postgres_clusters is not defined) or (postgres_clusters|length == 0)
 
 - include: postgres-cluster.yml
-    postgres_version={{ item.version }}
-    postgres_cluster_name={{ item.name }}
-    postgres_port={{ item.port }}
-    postgres_fsync_enabled={{ item.fsync_enabled }}
-    postgres_archive_enabled={{ item.archive_enabled }}
-    postgres_max_replication_slots={{ item.max_replication_slots | default(10) }}
-    postgres_extra_config={{ item.extra_config | default({}) }}
-    barman_directory={{ item.barman_directory | default(None) }}
-    postgres_primary={{ item.primary | default(None) }}
-    postgres_checksums={{ item.checksums | default(True) }}
-  with_items: "{{ postgres_clusters }}"
+  loop: "{{ postgres_clusters }}"
+  loop_control:
+    loop_var: postgres_cluster
   tags:
     - postgres
 
@@ -64,16 +56,9 @@
     - postgres-databases
 
 - include: postgres-pgupgrades.yml
-    postgres_dbname={{ item.dbname }}
-    postgres_pgbouncer_uri={{ item.pgbouncer_uri|default(None) }}
-    postgres_old_cluster_version={{ item.old_cluster_version }}
-    postgres_old_cluster_name={{ item.old_cluster_name }}
-    postgres_new_cluster_version={{ item.new_cluster_version }}
-    postgres_new_cluster_name={{ item.new_cluster_name }}
-    postgres_standby_server={{ item.standby_server }}
-    postgres_standby_old_cluster_name={{ item.standby_old_cluster_name|default(item.old_cluster_name) }}
-    postgres_standby_new_cluster_name={{ item.standby_new_cluster_name|default(item.new_cluster_name) }}
-  with_items: "{{ postgres_pgupgrades }}"
+  loop: "{{ postgres_pgupgrades }}"
+  loop_control:
+    loop_var: postgres_pgupgrade
   when: postgres_pgupgrades is defined
   tags:
     - postgres

--- a/tasks/postgres-cluster.yml
+++ b/tasks/postgres-cluster.yml
@@ -1,3 +1,16 @@
+---
+- set_fact:
+    postgres_version: "{{ postgres_cluster.version }}"
+    postgres_cluster_name: "{{ postgres_cluster.name }}"
+    postgres_port: "{{ postgres_cluster.port }}"
+    postgres_fsync_enabled: "{{ postgres_cluster.fsync_enabled }}"
+    postgres_archive_enabled: "{{ postgres_cluster.archive_enabled }}"
+    postgres_max_replication_slots: "{{ postgres_cluster.max_replication_slots | default(10) }}"
+    postgres_extra_config: "{{ postgres_cluster.extra_config | default({}) }}"
+    barman_directory: "{{ postgres_cluster.barman_directory | default(None) }}"
+    postgres_primary: "{{ postgres_cluster.primary | default(None) }}"
+    postgres_checksums: "{{ postgres_cluster.checksums | default(True) }}"
+
 - name: Install postgresql version {{ postgres_version }}
   apt: name=postgresql-{{ postgres_version }}
   when: ansible_distribution_release != 'NA'

--- a/tasks/postgres-pgupgrades.yml
+++ b/tasks/postgres-pgupgrades.yml
@@ -1,7 +1,18 @@
 ---
+- set_fact:
+    postgres_dbname: "{{ postgres_pgupgrade.dbname }}"
+    postgres_pgbouncer_uri: "{{ postgres_pgupgrade.pgbouncer_uri|default(None) }}"
+    postgres_old_cluster_version: "{{ postgres_pgupgrade.old_cluster_version }}"
+    postgres_old_cluster_name: "{{ postgres_pgupgrade.old_cluster_name }}"
+    postgres_new_cluster_version: "{{ postgres_pgupgrade.new_cluster_version }}"
+    postgres_new_cluster_name: "{{ postgres_pgupgrade.new_cluster_name }}"
+    postgres_standby_server: "{{ postgres_pgupgrade.standby_server }}"
+    postgres_standby_old_cluster_name: "{{ postgres_pgupgrade.standby_old_cluster_name|default(postgres_pgupgrade.old_cluster_name) }}"
+    postgres_standby_new_cluster_name: "{{ postgres_pgupgrade.standby_new_cluster_name|default(postgres_pgupgrade.new_cluster_name) }}"
+
 - name: Find matching new cluster
   set_fact:
-    postgres_new_cluster: "{{ postgres_clusters|selectattr('name','equalto',postgres_new_cluster_name)|selectattr('version','equalto',postgres_new_cluster_version|float)|list|first }}"
+    postgres_new_cluster: "{{ postgres_clusters|selectattr('name','equalto',postgres_new_cluster_name)|selectattr('version','equalto', postgres_new_cluster_version|float)|list|first }}"
 
 - name: Extract database port of new matching cluster
   set_fact:


### PR DESCRIPTION
With newer versions of Ansible we get an error on the existing `with_items` loop.

The following error occurs:

``` 1c-enterprise
TASK [postgresql : include] *************************************************************************************************************************************************
task path: vendor/postgresql/tasks/main.yml:22

fatal: [pg_01]: FAILED! => {
    "msg": "'item' is undefined"
}
fatal: [pg_02]: FAILED! => {
    "msg": "'item' is undefined"
}
```

This PR adds a dependency on Ansible >= 2.5 version