### PR TITLE
databases: add a list of schemas to database creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ postgres_clusters:                         # Mandatory
         extensions:                            # Optional
           - names: [ 'postgis', 'postgis_topology' ]
             apt_deps: [ 'postgresql-11-postgis' ]
+        schemas:                               # Optional
+          - name: 'custom_schema'
+            default_privileges: [ 'GRANT SELECT ON TABLES TO ro_user' ]
 
 # Postgres config (Optional)
 postgres_log_line_prefix: '%m [%p] database: %d host: %h user: %u '

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,6 +47,7 @@
     postgres_dbname={{ item.1.dbname }}
     postgres_owner={{ item.1.owner }}
     postgres_extensions={{ item.1.extensions|default([]) }}
+    postgres_schemas={{ item.1.schemas|default([]) }}
     postgres_port={{ item.0.port }}
   with_subelements:
     - "{{ postgres_clusters }}"

--- a/tasks/postgres-database-schemas.yml
+++ b/tasks/postgres-database-schemas.yml
@@ -1,0 +1,27 @@
+---
+- name: "CREATE SCHEMA on database {{ postgres_dbname }}"
+  become: true
+  become_user: postgres
+  become_method: su
+  postgresql_schema:
+    name:     "{{ postgres_schema.name }}"
+    database: "{{ postgres_dbname }}"
+    owner:    "{{ postgres_schema.owner|default(omit) }}"
+    port:     "{{ postgres_port }}"
+  when: postgres_up.rc == 0
+
+- name: "ALTER DEFAULT PRIVILEGES IN SCHEMA {{ postgres_schema.name }} on database {{ postgres_dbname }}"
+  become: true
+  become_user: postgres
+  become_method: su
+  # postgresql_privs module doesn't supper "alter default" until Ansible 2.7
+  # https://docs.ansible.com/ansible/latest/modules/postgresql_privs_module.html?highlight=ALL_DEFAULT
+  command: "psql --port={{ postgres_port }} --command='{{ postgres_command }}'"
+  vars:
+    postgres_command: "ALTER DEFAULT PRIVILEGES IN SCHEMA {{ postgres_schema.name }} {{ postgres_default_privilege }}"
+  check_mode: no
+  changed_when: false
+  loop: "{{ postgres_schemas.default_privileges|default([]) }}"
+  loop_control:
+    loop_var: postgres_default_privilege
+  when: postgres_up.rc == 0

--- a/tasks/postgres-database.yml
+++ b/tasks/postgres-database.yml
@@ -25,3 +25,10 @@
   loop_control:
     loop_var: postgres_extension
   when: postgres_up.rc == 0
+
+- name: Create extra database schemas (default PG schema is named public)
+  include_tasks: postgres-database-schemas.yml
+  loop: "{{ postgres_schemas| default([]) }}"
+  loop_control:
+    loop_var: postgres_schema
+  when: postgres_up.rc == 0

--- a/templates/pg_hba.conf.j2
+++ b/templates/pg_hba.conf.j2
@@ -102,6 +102,6 @@ host    all             all             ::1/128                 md5
 #local   replication     postgres                                peer
 #host    replication     postgres        127.0.0.1/32            md5
 #host    replication     postgres        ::1/128                 md5
-{% for host in postgres_replication_hosts %}
+{% for host in postgres_replication_hosts|default([]) %}
 hostssl replication   {{ host.user }}    {{ host.range }}        md5
 {% endfor %}

--- a/test/main.yml
+++ b/test/main.yml
@@ -68,6 +68,11 @@
                       - postgis
                       - postgis_topology
                       - btree_gist
+                schemas:
+                  - description: A readonly schema
+                    name: readonly
+                    default_privileges:
+                      - 'GRANT SELECT ON TABLES TO breakingtests'
 
       with_items:
         - postgres_one


### PR DESCRIPTION
This PR adds the ablity fore administrators to create schemas on top of databases.

The feature is tested in the test cases.

It adds the ability to:

- create schemas attached to a database
- (optionally) `ALTER DEFAULT PRIVILEGES` on the newly created schema

