### PR TITLE
recovery: optional restore_command & allow custom command if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ postgres_clusters:                         # Mandatory
     checksums: True                          # Optional
     fsync_enabled: False                     # Optional
     archive_enabled: False                   # Optional
+    wal_level: 'logical'                     # Optional
+    max_replication_slots: 10                # Optional
+    barman_directory: None                   # Optional
+    # Define cluster as a standby server
+    primary:                                 # Optional
+      host: '127.0.1.1'                        # Mandatory
+      port: 5433                               # Mandatory
+      replication_user:     'replicator'       # Mandatory
+      replication_password: 'SuperSecret'      # Mandatory
+      restore_command: None                    # Optional
+      restore_barman_directory: None           # Optional
     # List of users to be created (optional)
     users:
       - username: 'replicator'                 # Mandatory

--- a/templates/postgresql.12.conf.j2
+++ b/templates/postgresql.12.conf.j2
@@ -260,20 +260,18 @@ archive_command = ''
 
 # These are only used in recovery mode.
 
-{% if postgres_primary %}
 {# In PG < 12 versions all the recovery settings were in a separate recovery.conf file #}
-restore_command = '/usr/bin/barman-wal-restore --user barman --parallel 8 {{ postgres_barman_server }} {{ postgres_primary.restore_directory }} %f %p'		# command to use to restore an archived logfile segment
-				# placeholders: %p = path of file to restore
-				#               %f = file name only
-				# e.g. 'cp /mnt/server/archivedir/%f %p'
-				# (change requires restart)
+{% if postgres_primary and postgres_primary.restore_command is defined %}
+restore_command = '{{ postgres_primary.restore_command }}'		# command to use to restore an archived logfile segment
+{% elif postgres_primary and postgres_primary.restore_barman_directory is defined %}
+restore_command = '/usr/bin/barman-wal-restore --user barman --parallel 8 {{ postgres_barman_server }} {{ postgres_primary.restore_barman_directory }} %f %p'		# command to use to restore an archived logfile segment
 {% else %}
 #restore_command = ''		# command to use to restore an archived logfile segment
+{% endif %}
 				# placeholders: %p = path of file to restore
 				#               %f = file name only
 				# e.g. 'cp /mnt/server/archivedir/%f %p'
 				# (change requires restart)
-{% endif %}
 #archive_cleanup_command = ''	# command to execute at every restartpoint
 #recovery_end_command = ''	# command to execute at completion of recovery
 

--- a/templates/recovery.conf.j2
+++ b/templates/recovery.conf.j2
@@ -2,7 +2,11 @@
 # {{ ansible_managed }}
 
 standby_mode = 'on'
-restore_command = '/usr/bin/barman-wal-restore --user barman --parallel 8 {{ postgres_barman_server }} {{ postgres_primary.restore_directory }} %f %p'
+{% if postgres_primary.restore_command is defined %}
+restore_command = '{{ postgres_primary.restore_command }}'
+{% elif postgres_primary.restore_barman_directory is defined %}
+restore_command = '/usr/bin/barman-wal-restore --user barman --parallel 8 {{ postgres_barman_server }} {{ postgres_primary.restore_barman_directory }} %f %p'
+{% endif %}
 primary_conninfo = 'host={{ postgres_primary.host }} port={{ postgres_primary.port }} user={{ postgres_primary.replication_user }} password={{ postgres_primary.replication_password }} sslmode=require'
 trigger_file = '/var/lib/postgresql/{{ postgres_version }}/{{ postgres_cluster_name }}/failover.trigger'
 recovery_target_timeline='latest'

--- a/test/main.yml
+++ b/test/main.yml
@@ -91,7 +91,7 @@
             primary:
               host: postgres_one
               port: 5432
-              restore_directory: "{{ postgres_barman_directory }}"
+              restore_barman_directory: "{{ postgres_barman_directory }}"
               replication_user: "replicator"
               replication_password: "secret_repli"
 


### PR DESCRIPTION
Right now the role assumes you always want to use barman-wal-restore
script as a restore command to recover WAL files at startup time of a
standby server.

This PR adds a new `primary.restore_command` option which lets you
override the command to use.

⚠️ Breaking change: the PR renames the existing
`primary.restore_directory` option to
`primary.restore_barman_directory` ⚠️ in order to give more context to
this option which will automatically use the `barman-wal-restore`
script as a restore command.

Finally if none of the two options specified above are specified in
the `primary:` object then the `restore_command` is left commented out
in the PG configuration (which is totally fine as it will try to
recover WALs from the primary server directly see
[documentation](https://www.postgresql.org/docs/12/warm-standby.html#STANDBY-SERVER-OPERATION))