### PR TITLE
config: change 'work_mem' and 'maintenance_work_mem' default setting

### DIFF
--- a/templates/postgresql.10.conf.j2
+++ b/templates/postgresql.10.conf.j2
@@ -126,8 +126,22 @@ temp_buffers = 24MB			# min 800kB
 					# (change requires restart)
 # Caution: it is not advisable to set max_prepared_transactions nonzero unless
 # you actively intend to use prepared transactions.
-work_mem = 512MB				# min 64kB
-maintenance_work_mem = 1024MB		# min 1MB
+
+# https://info.crunchydata.com/blog/optimize-postgresql-server-performance
+# Set work_mem to 0.5% of the total available memory
+# it can be allocated multiple time concurrently)
+{% if postgres_work_mem is defined %}
+work_mem = {{ postgres_work_mem }}MB		# min 64kB
+{% else %}
+work_mem = {{ (ansible_memtotal_mb * 0.005) |int }}MB		# min 64kB
+{% endif %}
+# Set maintenance_work_mem to 5% of the total available memory
+# it can be allocated only once by PG maintenance tasks
+{% if postgres_maintenance_work_mem is defined %}
+maintenance_work_mem = {{ postgres_maintenance_work_mem }}MB	# min 1MB
+{% else %}
+maintenance_work_mem = {{ (ansible_memtotal_mb * 0.05) | int }}MB	# min 1MB
+{% endif %}
 #replacement_sort_tuples = 150000	# limits use of replacement selection sort
 #autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem
 #max_stack_depth = 2MB			# min 100kB

--- a/templates/postgresql.11.conf.j2
+++ b/templates/postgresql.11.conf.j2
@@ -127,8 +127,22 @@ temp_buffers = 24MB			# min 800kB
 					# (change requires restart)
 # Caution: it is not advisable to set max_prepared_transactions nonzero unless
 # you actively intend to use prepared transactions.
-work_mem = 512MB				# min 64kB
-maintenance_work_mem = 1024MB		# min 1MB
+
+# https://info.crunchydata.com/blog/optimize-postgresql-server-performance
+# Set work_mem to 0.5% of the total available memory
+# it can be allocated multiple time concurrently)
+{% if postgres_work_mem is defined %}
+work_mem = {{ postgres_work_mem }}MB		# min 64kB
+{% else %}
+work_mem = {{ (ansible_memtotal_mb * 0.005) |int }}MB		# min 64kB
+{% endif %}
+# Set maintenance_work_mem to 5% of the total available memory
+# it can be allocated only once by PG maintenance tasks
+{% if postgres_maintenance_work_mem is defined %}
+maintenance_work_mem = {{ postgres_maintenance_work_mem }}MB	# min 1MB
+{% else %}
+maintenance_work_mem = {{ (ansible_memtotal_mb * 0.05) | int }}MB	# min 1MB
+{% endif %}
 #autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem
 #max_stack_depth = 2MB			# min 100kB
 dynamic_shared_memory_type = posix	# the default is the first option

--- a/templates/postgresql.12.conf.j2
+++ b/templates/postgresql.12.conf.j2
@@ -132,8 +132,22 @@ temp_buffers = 24MB			# min 800kB
 					# (change requires restart)
 # Caution: it is not advisable to set max_prepared_transactions nonzero unless
 # you actively intend to use prepared transactions.
-work_mem = 512MB				# min 64kB
-maintenance_work_mem = 1024MB		# min 1MB
+
+# https://info.crunchydata.com/blog/optimize-postgresql-server-performance
+# Set work_mem to 0.5% of the total available memory
+# it can be allocated multiple time concurrently)
+{% if postgres_work_mem is defined %}
+work_mem = {{ postgres_work_mem }}MB		# min 64kB
+{% else %}
+work_mem = {{ (ansible_memtotal_mb * 0.005) |int }}MB		# min 64kB
+{% endif %}
+# Set maintenance_work_mem to 5% of the total available memory
+# it can be allocated only once by PG maintenance tasks
+{% if postgres_maintenance_work_mem is defined %}
+maintenance_work_mem = {{ postgres_maintenance_work_mem }}MB	# min 1MB
+{% else %}
+maintenance_work_mem = {{ (ansible_memtotal_mb * 0.05) | int }}MB	# min 1MB
+{% endif %}
 #autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem
 #max_stack_depth = 2MB			# min 100kB
 #shared_memory_type = mmap		# the default is the first option

--- a/templates/postgresql.9.5.conf.j2
+++ b/templates/postgresql.9.5.conf.j2
@@ -128,8 +128,22 @@ temp_buffers = 24MB			# min 800kB
 # per transaction slot, plus lock space (see max_locks_per_transaction).
 # It is not advisable to set max_prepared_transactions nonzero unless you
 # actively intend to use prepared transactions.
-work_mem = 512MB				# min 64kB
-maintenance_work_mem = 1024MB		# min 1MB
+
+# https://info.crunchydata.com/blog/optimize-postgresql-server-performance
+# Set work_mem to 0.5% of the total available memory
+# it can be allocated multiple time concurrently)
+{% if postgres_work_mem is defined %}
+work_mem = {{ postgres_work_mem }}MB		# min 64kB
+{% else %}
+work_mem = {{ (ansible_memtotal_mb * 0.005) |int }}MB		# min 64kB
+{% endif %}
+# Set maintenance_work_mem to 5% of the total available memory
+# it can be allocated only once by PG maintenance tasks
+{% if postgres_maintenance_work_mem is defined %}
+maintenance_work_mem = {{ postgres_maintenance_work_mem }}MB	# min 1MB
+{% else %}
+maintenance_work_mem = {{ (ansible_memtotal_mb * 0.05) | int }}MB	# min 1MB
+{% endif %}
 #autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem
 #max_stack_depth = 2MB			# min 100kB
 dynamic_shared_memory_type = posix	# the default is the first option

--- a/templates/postgresql.9.6.conf.j2
+++ b/templates/postgresql.9.6.conf.j2
@@ -130,8 +130,22 @@ temp_buffers = 24MB			# min 800kB
 # per transaction slot, plus lock space (see max_locks_per_transaction).
 # Caution: it is not advisable to set max_prepared_transactions nonzero unless
 # you actively intend to use prepared transactions.
-work_mem = 512MB				# min 64kB
-maintenance_work_mem = 1024MB		# min 1MB
+
+# https://info.crunchydata.com/blog/optimize-postgresql-server-performance
+# Set work_mem to 0.5% of the total available memory
+# it can be allocated multiple time concurrently)
+{% if postgres_work_mem is defined %}
+work_mem = {{ postgres_work_mem }}MB		# min 64kB
+{% else %}
+work_mem = {{ (ansible_memtotal_mb * 0.005) |int }}MB		# min 64kB
+{% endif %}
+# Set maintenance_work_mem to 5% of the total available memory
+# it can be allocated only once by PG maintenance tasks
+{% if postgres_maintenance_work_mem is defined %}
+maintenance_work_mem = {{ postgres_maintenance_work_mem }}MB	# min 1MB
+{% else %}
+maintenance_work_mem = {{ (ansible_memtotal_mb * 0.05) | int }}MB	# min 1MB
+{% endif %}
 #replacement_sort_tuples = 150000	# limits use of replacement selection sort
 #autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem
 #max_stack_depth = 2MB			# min 100kB


### PR DESCRIPTION
The current defaults set by this role is pretty high (`work_mem =
512MB`) this is fine on very big machines (with more than 32GB of RAM)
but not compatible with smaller machines (with 4GB of RAM).

This change adds two new optionnal role variables `postgres_work_mem`
and `postgres_maintenance_work_mem` to be able to set a custom size to
your needs.

It also tries to set sensible defaults to:
- default value for `work_mem` to 0.5 % of the total available memory
  of the machine
- default value for `maintenance_work_mem` to 5% of the total
available memory of the machine

P.S.: here is a good explanation about those configuration option
https://info.crunchydata.com/blog/optimize-postgresql-server-performance