### PR TITLE
fix: use modern way of passing variables to included task file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,27 +31,23 @@
     - postgres
 
 - include: postgres-user.yml
-    postgres_username={{ item.1.username }}
-    postgres_password={{ item.1.password }}
-    postgres_port={{ item.0.port }}
-    postgres_permissions={{ item.1.permissions | default('') }}
-  with_subelements:
-    - "{{ postgres_clusters }}"
-    - users
-    - skip_missing: true
+  vars:
+    postgres_username: "{{ item.1.username }}"
+    postgres_password: "{{ item.1.password }}"
+    postgres_port: "{{ item.0.port }}"
+    postgres_permissions: "{{ item.1.permissions | default('') }}"
+  loop: "{{ q('subelements', postgres_clusters, 'users', {'skip_missing': True}) }}"
   tags:
     - postgres
     - postgres-users
 
 - include: postgres-database.yml
-    postgres_dbname={{ item.1.dbname }}
-    postgres_owner={{ item.1.owner }}
-    postgres_extensions={{ item.1.extensions|default([]) }}
-    postgres_port={{ item.0.port }}
-  with_subelements:
-    - "{{ postgres_clusters }}"
-    - databases
-    - skip_missing: true
+  vars:
+    postgres_dbname: "{{ item.1.dbname }}"
+    postgres_owner: "{{ item.1.owner }}"
+    postgres_extensions: "{{ item.1.extensions|default([]) }}"
+    postgres_port: "{{ item.0.port }}"
+  loop: "{{ q('subelements', postgres_clusters, 'databases', {'skip_missing': True}) }}"
   tags:
     - postgres
     - postgres-databases

--- a/tasks/postgres-database.yml
+++ b/tasks/postgres-database.yml
@@ -1,4 +1,4 @@
-- name: Test if the PostgreSQL server is up
+- name: Test if the PostgreSQL server (on port {{ postgres_port }}) is up
   become: true
   become_user: postgres
   become_method: "{{ postgres_become_method }}"

--- a/tasks/postgres-user.yml
+++ b/tasks/postgres-user.yml
@@ -1,4 +1,4 @@
-- name: Test if the PostgreSQL server is up
+- name: Test if the PostgreSQL server (on port {{ postgres_port }}) is up
   become: true
   become_user: postgres
   become_method: "{{ postgres_become_method }}"


### PR DESCRIPTION
Since a while (I believe 2.6) ansible doesn't allow variables
passing with the `include:` statement. We need to explicit the `vars:`
argument for it to work properly.

I have also changed the `with_subelements` loop to use the more modern
`loop` iterator.

This fixes a bug where users / databases were not created on pg
clusters when you are trying to configure multiple clusters on a
host (when `postgres_clusters|length > 1`).