### PR TITLE
Allow to specify barman options per cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,14 @@ postgres_clusters:                         # Mandatory
     archive_enabled: False                   # Optional
     wal_level: 'logical'                     # Optional
     max_replication_slots: 10                # Optional
-    barman_directory: None                   # Optional
+    barman:                                  # Required if archive_enabled is enabled
+      directory: 'main-v11'                    # Required. Should includes the PostgreSQL major version
+      server: barman.example.com               # Required
+      server_ansible_host: ssh.example.com     # Optional, will be used in place of "server" for Ansible SSH connection
+      rsync_enabled: False                     # Optional, will overwrite global variable postgres_barman_rsync_enabled
+      rsync_options: ''                        # Optional, will overwrite global variable postgres_barman_rsync_options
+      remote_user: barman                      # Optional, will overwrite global variable postgres_barman_remote_user
+      path_prefix: '~'                         # Optional, will overwrite global variable postgres_barman_path_prefix
     # Define cluster as a standby server
     primary:                                 # Optional
       host: '127.0.1.1'                        # Mandatory
@@ -91,7 +98,6 @@ postgres_replication_hosts:
 postgres_become_method: su  # Optional
 
 # Barman connectivity
-postgres_barman_server: barman.example.com  # Required if at least one server has archive_enabled enabled
 postgres_barman_rsync_enabled: False        # Optional
 postgres_barman_rsync_options: ''           # Optional
 postgres_barman_remote_user: barman         # Optional

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ postgres_clusters: []
 # postgres_pgbadger_server: ~
 postgres_backup_enabled: false
 postgres_barman_rsync_enabled: false
+postgres_barman_rsync_options: ''
 postgres_barman_remote_user: barman
 
 postgres_become_method: su

--- a/tasks/postgres-cluster.yml
+++ b/tasks/postgres-cluster.yml
@@ -8,9 +8,20 @@
     postgres_wal_level: "{{ postgres_cluster.wal_level|default('logical') }}"
     postgres_max_replication_slots: "{{ postgres_cluster.max_replication_slots | default(10) }}"
     postgres_extra_config: "{{ postgres_cluster.extra_config | default({}) }}"
-    barman_directory: "{{ postgres_cluster.barman_directory | default(None) }}"
     postgres_primary: "{{ postgres_cluster.primary | default(None) }}"
     postgres_checksums: "{{ postgres_cluster.checksums | default(True) }}"
+    barman_directory: "{{ postgres_cluster.barman_directory | default(None) }}"
+    barman: "{{ postgres_cluster.barman | default(None) }}"
+
+- set_fact:
+    barman_server: "{{ barman.server }}"
+    barman_directory: "{{ barman.directory }}"
+    barman_server_ansible_host: "{{ barman.server_ansible_host | default(barman.server) }}"
+    barman_rsync_enabled: "{{ barman.rsync_enabled | default(postgres_barman_rsync_enabled) }}"
+    barman_rsync_options: "{{ barman.rsync_options | default(postgres_barman_rsync_options) }}"
+    barman_remote_user: "{{ barman.remote_user | default(postgres_barman_remote_user) }}"
+    barman_path_prefix: "{{ barman.path_prefix | default(postgres_barman_path_prefix) }}"
+  when: postgres_archive_enabled
 
 - name: Install postgresql version {{ postgres_version }}
   apt: name=postgresql-{{ postgres_version }}
@@ -60,7 +71,7 @@
 
 - name: Add standby clone from barman script
   include: postgres-standby-barman.yml
-  when: postgres_barman_server is defined and postgres_primary.restore_barman_directory is defined
+  when: barman_server is defined and postgres_primary.restore_barman_directory is defined
 
 - name: Add standby clone from pg_basebackup
   include: postgres-standby-basebackup.yml
@@ -109,3 +120,27 @@
 - name: Create log symlink for pg_lsclusters
   file: dest=/etc/postgresql/{{ postgres_version }}/{{ postgres_cluster_name }}/log src={{ postgres_log_dir }}/postgresql-{{ postgres_version }}-{{ postgres_cluster_name }}.log state=link
   when: postgres_log_dir is defined and postgres_log_dir
+
+- slurp:
+    src: /var/lib/postgresql/.ssh/id_rsa.pub
+  register: db_server_pub_key
+
+- name: Check if barman is installed on barman server
+  getent:
+    database: passwd
+    key: "barman"
+  delegate_to: "{{ barman_server_ansible_host|default(barman_server) }}"
+  when: barman_server is defined
+  register: barman_user_exists
+  ignore_errors: true
+  changed_when: false
+
+- name: Allow SSH access on barman server
+  authorized_key:
+    user: "barman"
+    key: "{{ db_server_pub_key['content']|b64decode }}"
+    state: present
+  delegate_to: "{{ barman_server_ansible_host|default(barman_server) }}"
+  when:
+    - barman_server is defined
+    - barman_user_exists is succeeded

--- a/tasks/postgres-common-postinstall.yml
+++ b/tasks/postgres-common-postinstall.yml
@@ -11,30 +11,6 @@
   args:
     creates: /var/lib/postgresql/.ssh/id_rsa
 
-- slurp:
-    src: /var/lib/postgresql/.ssh/id_rsa.pub
-  register: db_server_pub_key
-
-- name: Check if barman is installed on barman server
-  getent:
-    database: passwd
-    key: "barman"
-  delegate_to: "{{ postgres_barman_server_public|default(postgres_barman_server) }}"
-  when: postgres_barman_server is defined
-  register: barman_user_exists
-  ignore_errors: true
-  changed_when: false
-
-- name: Allow SSH access on barman server
-  authorized_key:
-    user: "barman"
-    key: "{{ db_server_pub_key['content']|b64decode }}"
-    state: present
-  delegate_to: "{{ postgres_barman_server_public|default(postgres_barman_server) }}"
-  when:
-    - postgres_barman_server is defined
-    - barman_user_exists is succeeded
-
 - name: Copy logrotate configuration for postgresql
   template: src=logrotate-postgresql-common.j2 dest=/etc/logrotate.d/postgresql-common owner=root group=root mode=0644
 

--- a/tasks/postgres-standby-barman.yml
+++ b/tasks/postgres-standby-barman.yml
@@ -2,14 +2,14 @@
 - name: Compute barman remote URL
   set_fact:
     barman_remote_url: "{{ scheme }}{{ user }}{{ server }}{{ delimiter }}{{ path }}"
-    rsync_options: "{{ postgres_barman_rsync_options | default('') }}{{ rsync_password_file }}"
+    rsync_options: "{{ barman_rsync_options | default('') }}{{ rsync_password_file }}"
   vars:
-    scheme: "{{ postgres_barman_rsync_enabled | ternary('rsync://', '') }}"
-    user: "{{ postgres_barman_remote_user is defined | ternary(postgres_barman_remote_user + '@', '') }}"
-    server: "{{ postgres_barman_server }}"
-    delimiter: "{{ postgres_barman_rsync_enabled | ternary('', ':')}}"
-    path: "{{ postgres_barman_path_prefix | default('~') }}"
-    rsync_password_file: "{{ postgres_barman_rsync_enabled | ternary(' --password-file=/var/lib/postgresql/.rsync_pass ', '') }}"
+    scheme: "{{ barman_rsync_enabled | ternary('rsync://', '') }}"
+    user: "{{ barman_remote_user is defined | ternary(barman_remote_user + '@', '') }}"
+    server: "{{ barman_server }}"
+    delimiter: "{{ barman_rsync_enabled | ternary('', ':')}}"
+    path: "{{ barman_path_prefix | default('~') }}"
+    rsync_password_file: "{{ barman_rsync_enabled | ternary(' --password-file=/var/lib/postgresql/.rsync_pass ', '') }}"
 
 - name: Copy secondary barman clone script
   template: src=standby-barman-clone.sh.j2 dest=/root/standby-clone-{{ postgres_version }}-{{ postgres_cluster_name }}.sh mode=0755
@@ -22,4 +22,4 @@
     group: postgres
     mode: 0400
   no_log: True
-  when: postgres_barman_rsync_enabled
+  when: barman_rsync_enabled

--- a/templates/postgresql.10.conf.j2
+++ b/templates/postgresql.10.conf.j2
@@ -242,7 +242,7 @@ wal_log_hints = on			# also do full page writes of non-critical updates
 
 {% if postgres_archive_enabled %}
 archive_mode = on
-archive_command = 'rsync -a %p {{ postgres_barman_remote_user }}@{{ postgres_barman_server }}:/var/lib/barman/{{ barman_directory }}/incoming/%f'
+archive_command = 'rsync -a %p {{ barman_remote_user }}@{{ barman_server }}:/var/lib/barman/{{ barman_directory }}/incoming/%f'
 {% else %}
 archive_mode = off
 archive_command = ''

--- a/templates/postgresql.11.conf.j2
+++ b/templates/postgresql.11.conf.j2
@@ -243,7 +243,7 @@ min_wal_size = 80MB
 
 {% if postgres_archive_enabled %}
 archive_mode = on
-archive_command = 'rsync -a %p barman@{{ postgres_barman_server }}:/var/lib/barman/{{ barman_directory }}/incoming/%f'
+archive_command = 'rsync -a %p barman@{{ barman_server }}:/var/lib/barman/{{ barman_directory }}/incoming/%f'
 {% else %}
 archive_mode = off
 archive_command = ''

--- a/templates/postgresql.12.conf.j2
+++ b/templates/postgresql.12.conf.j2
@@ -255,7 +255,7 @@ min_wal_size = 80MB
 
 {% if postgres_archive_enabled %}
 archive_mode = on
-archive_command = 'rsync -a %p barman@{{ postgres_barman_server }}:/var/lib/barman/{{ barman_directory }}/incoming/%f'
+archive_command = 'rsync -a %p barman@{{ barman_server }}:/var/lib/barman/{{ barman_directory }}/incoming/%f'
 {% else %}
 archive_mode = off
 archive_command = ''
@@ -278,7 +278,7 @@ archive_command = ''
 {% if postgres_primary and postgres_primary.restore_command is defined %}
 restore_command = '{{ postgres_primary.restore_command }}'		# command to use to restore an archived logfile segment
 {% elif postgres_primary and postgres_primary.restore_barman_directory is defined %}
-restore_command = '/usr/bin/barman-wal-restore --user barman --parallel 8 {{ postgres_barman_server }} {{ postgres_primary.restore_barman_directory }} %f %p'		# command to use to restore an archived logfile segment
+restore_command = '/usr/bin/barman-wal-restore --user barman --parallel 8 {{ barman_server }} {{ postgres_primary.restore_barman_directory }} %f %p'		# command to use to restore an archived logfile segment
 {% else %}
 #restore_command = ''		# command to use to restore an archived logfile segment
 {% endif %}

--- a/templates/postgresql.9.1.conf.j2
+++ b/templates/postgresql.9.1.conf.j2
@@ -161,7 +161,7 @@ wal_level = 'hot_standby' # For PostgreSQL >= 9.0
 
 {% if postgres_archive_enabled %}
 archive_mode = on
-archive_command = 'rsync -a %p barman@{{ postgres_barman_server }}:/var/lib/barman/{{ barman_directory }}/incoming/%f'
+archive_command = 'rsync -a %p barman@{{ barman_server }}:/var/lib/barman/{{ barman_directory }}/incoming/%f'
 {% else %}
 archive_mode = off
 archive_command = ''

--- a/templates/postgresql.9.4.conf.j2
+++ b/templates/postgresql.9.4.conf.j2
@@ -216,7 +216,7 @@ wal_log_hints = on			# also do full page writes of non-critical updates
 
 {% if postgres_archive_enabled %}
 archive_mode = on
-archive_command = 'rsync -a %p barman@{{ postgres_barman_server }}:/var/lib/barman/{{ barman_directory }}/incoming/%f'
+archive_command = 'rsync -a %p barman@{{ barman_server }}:/var/lib/barman/{{ barman_directory }}/incoming/%f'
 {% else %}
 archive_mode = off
 archive_command = ''

--- a/templates/postgresql.9.5.conf.j2
+++ b/templates/postgresql.9.5.conf.j2
@@ -232,7 +232,7 @@ wal_log_hints = on			# also do full page writes of non-critical updates
 
 {% if postgres_archive_enabled %}
 archive_mode = on
-archive_command = 'rsync -a %p barman@{{ postgres_barman_server }}:/var/lib/barman/{{ barman_directory }}/incoming/%f'
+archive_command = 'rsync -a %p barman@{{ barman_server }}:/var/lib/barman/{{ barman_directory }}/incoming/%f'
 {% else %}
 archive_mode = off
 archive_command = ''

--- a/templates/postgresql.9.6.conf.j2
+++ b/templates/postgresql.9.6.conf.j2
@@ -244,7 +244,7 @@ wal_log_hints = on			# also do full page writes of non-critical updates
 
 {% if postgres_archive_enabled %}
 archive_mode = on
-archive_command = 'rsync -a %p barman@{{ postgres_barman_server }}:/var/lib/barman/{{ barman_directory }}/incoming/%f'
+archive_command = 'rsync -a %p barman@{{ barman_server }}:/var/lib/barman/{{ barman_directory }}/incoming/%f'
 {% else %}
 archive_mode = off
 archive_command = ''

--- a/templates/recovery.conf.j2
+++ b/templates/recovery.conf.j2
@@ -4,8 +4,8 @@
 standby_mode = 'on'
 {% if postgres_primary.restore_command is defined %}
 restore_command = '{{ postgres_primary.restore_command }}'
-{% elif postgres_primary.restore_barman_directory is defined %}
-restore_command = '/usr/bin/barman-wal-restore --user barman --parallel 8 {{ postgres_barman_server }} {{ postgres_primary.restore_barman_directory }} %f %p'
+{% elif postgres_primary.restore_barman_directory is defined and barman_server is defined %}
+restore_command = '/usr/bin/barman-wal-restore --user barman --parallel 8 {{ barman_server }} {{ postgres_primary.restore_barman_directory }} %f %p'
 {% endif %}
 primary_conninfo = 'host={{ postgres_primary.host }} port={{ postgres_primary.port }} user={{ postgres_primary.replication_user }} password={{ postgres_primary.replication_password }} sslmode=require'
 trigger_file = '/var/lib/postgresql/{{ postgres_version }}/{{ postgres_cluster_name }}/failover.trigger'

--- a/templates/standby-barman-clone.sh.j2
+++ b/templates/standby-barman-clone.sh.j2
@@ -16,7 +16,7 @@ fi
 BACKUP_DATE=`date +%s`
 
 echo "accept key if necessary"
-sudo -u postgres ssh barman@{{ postgres_barman_server }} echo ""
+sudo -u postgres ssh barman@{{ barman_server }} echo ""
 
 echo Stopping PostgreSQL
 pg_ctlcluster {{ postgres_version }} {{ postgres_cluster_name }} stop || true

--- a/test/main.yml
+++ b/test/main.yml
@@ -2,10 +2,11 @@
 - name: Bring up docker containers
   hosts: localhost
   vars: &common_vars
-    postgres_barman_directory: "test-postgres-{{ postgres_version }}"
-    postgres_barman_server: postgres_barman
-    barman_rsync_password: "secret_rsync"
-    barman_rsync_allowed_hosts: 172.17.0.0/24
+    barman: &common_barman_vars
+      directory: "test-postgres-{{ postgres_version }}"
+      server: postgres_barman
+      rsync_password: "secret_rsync"
+      rsync_allowed_hosts: 172.17.0.0/24
     postgres_allowed_hosts:
       - user: all
         range: 172.17.0.0/24
@@ -13,21 +14,21 @@
       - user: replicator
         range: 172.17.0.0/24
     inventory:
-      - name: "{{ postgres_barman_server }}"
+      - name: "{{ barman.server }}"
         image: "python:3.7-{{ debian_release }}"
       - name: postgres_one
         image: "python:3.7-{{ debian_release }}"
         links:
-          - "{{ postgres_barman_server }}"
+          - "{{ barman.server }}"
       - name: postgres_two
         image: "python:3.7-{{ debian_release }}"
         links:
-          - "{{ postgres_barman_server }}"
+          - "{{ barman.server }}"
           - postgres_one
       - name: postgres_three
         image: "python:3.7-{{ debian_release }}"
         links:
-          - "{{ postgres_barman_server }}"
+          - "{{ barman.server }}"
           - postgres_one
   roles:
     - role: provision_docker
@@ -49,7 +50,9 @@
             fsync_enabled: True
             checksums: False
             archive_enabled: True
-            barman_directory: "{{ postgres_barman_directory }}"
+            barman:
+              <<: *common_barman_vars
+              directory: "{{ postgres_barman_directory }}"
             users:
               - username: tester
                 password: tester
@@ -87,7 +90,9 @@
             fsync_enabled: True
             checksums: False
             archive_enabled: True
-            barman_directory: "{{ postgres_barman_directory }}"
+            barman:
+              <<: *common_barman_vars
+              directory: "{{ postgres_barman_directory }}"
             primary:
               host: postgres_one
               port: 5432


### PR DESCRIPTION
We may configure multiple PostgreSQL clusters on the same host.
Those clusters may use differente barman servers.

This breaks compatilibity with previous configurations.