### PR TITLE
Enable configuring max_standby_archive_delay

### DIFF
--- a/templates/postgresql.10.conf.j2
+++ b/templates/postgresql.10.conf.j2
@@ -296,7 +296,7 @@ max_replication_slots = {{ postgres_max_replication_slots }} # max number of rep
 
 hot_standby = on			# "off" disallows queries during recovery
 					# (change requires restart)
-#max_standby_archive_delay = 30s	# max delay before canceling queries
+max_standby_archive_delay = {{ postgres_extra_config.max_standby_archive_delay | default('30s') }} # max delay before canceling queries
 					# when reading WAL from archive;
 					# -1 allows indefinite delay
 max_standby_streaming_delay = {{ postgres_extra_config.max_standby_streaming_delay | default('600s') }}	# max delay before canceling queries

--- a/templates/postgresql.11.conf.j2
+++ b/templates/postgresql.11.conf.j2
@@ -297,7 +297,7 @@ max_replication_slots = {{ postgres_max_replication_slots }} # max number of rep
 
 hot_standby = on			# "off" disallows queries during recovery
 					# (change requires restart)
-#max_standby_archive_delay = 30s	# max delay before canceling queries
+max_standby_archive_delay = {{ postgres_extra_config.max_standby_archive_delay | default('30s') }} # max delay before canceling queries
 					# when reading WAL from archive;
 					# -1 allows indefinite delay
 max_standby_streaming_delay = {{ postgres_extra_config.max_standby_streaming_delay | default('600s') }}	# max delay before canceling queries

--- a/templates/postgresql.12.conf.j2
+++ b/templates/postgresql.12.conf.j2
@@ -373,7 +373,7 @@ promote_trigger_file = '/var/lib/postgresql/{{ postgres_version }}/{{ postgres_c
 {% endif %}
 hot_standby = on			# "off" disallows queries during recovery
 					# (change requires restart)
-#max_standby_archive_delay = 30s	# max delay before canceling queries
+max_standby_archive_delay = {{ postgres_extra_config.max_standby_archive_delay | default('30s') }} # max delay before canceling queries
 					# when reading WAL from archive;
 					# -1 allows indefinite delay
 max_standby_streaming_delay = {{ postgres_extra_config.max_standby_streaming_delay | default('600s') }}	# max delay before canceling queries

--- a/templates/postgresql.9.1.conf.j2
+++ b/templates/postgresql.9.1.conf.j2
@@ -236,11 +236,10 @@ synchronous_commit = off		# synchronization level;
 
 #hot_standby = off			# "on" allows queries during recovery
 					# (change requires restart)
-#max_standby_archive_delay = 30s	# max delay before canceling queries
+max_standby_archive_delay = {{ postgres_extra_config.max_standby_archive_delay | default('30s') }} # max delay before canceling queries
 					# when reading WAL from archive;
 					# -1 allows indefinite delay
-max_standby_streaming_delay = 600s
-#max_standby_streaming_delay = 30s	# max delay before canceling queries
+max_standby_streaming_delay = {{ postgres_extra_config.max_standby_streaming_delay | default('600s') }} # max delay before canceling queries
 					# when reading streaming WAL;
 					# -1 allows indefinite delay
 #wal_receiver_status_interval = 10s	# send replies at least this often

--- a/templates/postgresql.9.4.conf.j2
+++ b/templates/postgresql.9.4.conf.j2
@@ -267,7 +267,7 @@ max_replication_slots = {{ postgres_max_replication_slots }} # max number of rep
 
 hot_standby = on			# "on" allows queries during recovery
 					# (change requires restart)
-#max_standby_archive_delay = 30s	# max delay before canceling queries
+max_standby_archive_delay = {{ postgres_extra_config.max_standby_archive_delay | default('30s') }} # max delay before canceling queries
 					# when reading WAL from archive;
 					# -1 allows indefinite delay
 max_standby_streaming_delay = {{ postgres_extra_config.max_standby_streaming_delay | default('600s') }}	# max delay before canceling queries

--- a/templates/postgresql.9.5.conf.j2
+++ b/templates/postgresql.9.5.conf.j2
@@ -285,7 +285,7 @@ max_replication_slots = {{ postgres_max_replication_slots }} # max number of rep
 
 hot_standby = on			# "on" allows queries during recovery
 					# (change requires restart)
-#max_standby_archive_delay = 30s	# max delay before canceling queries
+max_standby_archive_delay = {{ postgres_extra_config.max_standby_archive_delay | default('30s') }} # max delay before canceling queries
 					# when reading WAL from archive;
 					# -1 allows indefinite delay
 max_standby_streaming_delay = {{ postgres_extra_config.max_standby_streaming_delay | default('600s') }}	# max delay before canceling queries

--- a/templates/postgresql.9.6.conf.j2
+++ b/templates/postgresql.9.6.conf.j2
@@ -297,7 +297,7 @@ max_replication_slots = {{ postgres_max_replication_slots }} # max number of rep
 
 hot_standby = on			# "on" allows queries during recovery
 					# (change requires restart)
-#max_standby_archive_delay = 30s	# max delay before canceling queries
+max_standby_archive_delay = {{ postgres_extra_config.max_standby_archive_delay | default('30s') }} # max delay before canceling queries
 					# when reading WAL from archive;
 					# -1 allows indefinite delay
 max_standby_streaming_delay = 600s	# max delay before canceling queries


### PR DESCRIPTION
If for any reason the replica starts lagging behind the primary server, requiring recovery from WAL archives, all queries above 30 seconds get aborted.
On some cold standby replicas this may be a not desired behavior.